### PR TITLE
Improve query parser

### DIFF
--- a/tests/timer/test_query_parser.py
+++ b/tests/timer/test_query_parser.py
@@ -14,6 +14,24 @@ def test_parse_query__5__is_correct_query():
     assert parse_query('5') == (5 * 60, '5', 'Time is up!')
 
 
+def test_parse_query__5h_37m_hello__correct_result_returned():
+    assert parse_query('5h37m hello') == (5 * 60 * 60 + 37 * 60, '5h37m', 'hello')
+
+
+def test_parse_query__1h_2s_hello__correct_result_returned():
+    assert parse_query('1h2s hello') == (1 * 60 * 60 + 2, '1h2s', 'hello')
+
+def test_parse_query__2m_5s__is_correct_query():
+    assert parse_query('2m5s') == (2*60 + 5, '2m5s', 'Time is up!')
+
+
+def test_pasrse_query__is_case_insensitive():
+    assert parse_query('1H2M3S') == (1 * 60 * 60 + 2 * 60 + 3, '1H2M3S', 'Time is up!')
+
 def test_parse_query__incorrect_query__ParseQueryError():
     with pytest.raises(ParseQueryError):
         assert parse_query('wfa')
+
+def test_parse_query__incorrect_query_with_no_units__ParseQueryError():
+    with pytest.raises(ParseQueryError):
+        assert parse_query('1h3')

--- a/timer/query_parser.py
+++ b/timer/query_parser.py
@@ -1,11 +1,35 @@
 import re
 
 
-TIME_MULT = {
-    'h': 60 * 60,
-    'm': 60,
-    's': 1
-}
+time_regex = re.compile(
+    r'^((?P<time_hours>\d+)h)?'
+    r'((?P<time_minutes>\d+)m)?'
+    r'((?P<time_seconds>\d+)s)?'
+    r'(?P<time_nounits>\d+)?$',
+    re.I
+)
+
+
+def parse_time_str(time_str):
+    """
+    >>> '5h'
+    <<< (5, 0, 0)
+    >>> '5m'
+    <<< (0, 5, 0)
+    >>> '5s'
+    <<< (0, 0, 5)
+    >>> '1h2m3s'
+    <<< (1, 2, 3)
+    """
+    match = time_regex.match(time_str)
+    hours = int(match.group('time_hours') or 0)
+    minutes = int(match.group('time_minutes') or 0)
+    seconds = int(match.group('time_seconds') or 0)
+    no_units = int(match.group('time_nounits') or 0)
+    if no_units != 0 and (hours > 0 or minutes > 0 or seconds > 0):
+        raise ValueError("Bad format: time value with no unit is not allowed if values with units are present")
+
+    return hours, minutes + no_units, seconds
 
 
 def parse_query(query, default_text='Time is up!'):
@@ -20,8 +44,8 @@ def parse_query(query, default_text='Time is up!'):
     try:
         time_arg = query.split(' ')[0]
         assert time_arg, "Incorrect time"
-        m = re.match(r'^(?P<time>\d+)(?P<measure>[mhs])?$', time_arg, re.I)
-        time_sec = int(m.group('time')) * TIME_MULT[(m.group('measure') or 'm').lower()]
+        hours, minutes, seconds = parse_time_str(time_arg)
+        time_sec = hours*60*60 + minutes*60 + seconds
 
         message = ' '.join(query.split(' ')[1:]).strip()
         message = message or default_text


### PR DESCRIPTION
Add support for time arguments like "1h30m", "10m12s" etc. All previous behaviour is left as-is (existing tests pass)

Somewhat related to #1 since it makes possible to use partial time